### PR TITLE
Update vance-sidebar-resizer.js

### DIFF
--- a/vance-sidebar-resizer.js
+++ b/vance-sidebar-resizer.js
@@ -37,9 +37,9 @@ Hooks.on("ready", function() {
     function resize(e) {
         newSize = startSize + mouseStart - e.clientX;
         if (newSize >= minSize) {
-            sidebar.style.width = `${newSize}px`;
+            sidebar.style.width = `${newSize}px!important`;
         } else {
-            sidebar.style.width = `${minSize}px`;
+            sidebar.style.width = `${minSize}px!important`;
         }
     }
 


### PR DESCRIPTION
Foundry's CSS width on #sidebar is now: `width:350px !important;`. This means the width being set by the plugin, even though it's on the DOM element, must also include !important otherwise it will not take precedence over the default.

Screencast: https://d.pr/v/e9CzIs