### PR TITLE
Change to renderSidebar hook

### DIFF
--- a/vance-sidebar-resizer.js
+++ b/vance-sidebar-resizer.js
@@ -1,4 +1,4 @@
-Hooks.on("ready", function() {
+Hooks.once("renderSidebar", function() {
   // Setup vars
   let important = '';
   let minSize = 300;


### PR DESCRIPTION
By changing to activate on the first call of the renderSidebar hook, we can bypass a split second moment on first loading in when the sidebar shows as the incorrect width. I haven't noticed any issues being caused by this change, though I admit my testing has not been exhaustive.